### PR TITLE
Add Together API support for Llama models

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ python main_tog2.py \
 --self_consistency_threshold 0.8 \  # self-consistency threshold, 0.8 is the default setting.
 --clue_query True \  # whether use clue query.
 ```
+
+### Using Together's Llama models
+To run ToG-2 with a Llama model hosted on [Together](https://www.together.ai/), install the `together` package and supply your Together API key via `--opeani_api_keys`. Setting `--LLM_type llama` will use the `meta-llama/Meta-Llama-3.1-8B-Instruct` model by default.
+
 ### Example: Our experimental script for HotpotQA.
 ```
 cd ToG-2

--- a/ToG-2/README.md
+++ b/ToG-2/README.md
@@ -13,9 +13,11 @@ python main_tog2.py \
 --LLM_type gpt-3.5-turbo \  # the LLM you choose for other generations.
 --opeani_api_keys <api_key> \  # your own api key, if LLM_type is local LLMs, this parameter would be rendered ineffective.
 --embedding_model_name <search_model_name> \  # model name for text search. "bge-bi" (bge embedding), "bge-ce" (bge reranker),"bm25","minilm" (ms-marco-MiniLM-L-6-v2) and "colbert" (bge-m3).
---relation_prune_combination True\  # whether perform relation_prune_combination. 
+--relation_prune_combination True\  # whether perform relation_prune_combination.
 --num_sents_for_reasoning 10 \  # number of sentences retained for reasoning. 10 is the default setting.
 --topic_prune True \  # whether perform topic prune.
 --self_consistency_threshold 0.8 \  # self-consistency threshold, 0.8 is the default setting.
 --clue_query \  # whether use clue query.
 ```
+
+Setting `--LLM_type llama` will call the `meta-llama/Meta-Llama-3.1-8B-Instruct` model via the Together API. Provide your Together API key with `--opeani_api_keys`.

--- a/ToG-2/utils.py
+++ b/ToG-2/utils.py
@@ -6,7 +6,7 @@ import os
 from prompt_list import *
 from rank_bm25 import BM25Okapi
 from sentence_transformers import util
-from openai import OpenAI
+from together import Together
 
 def retrieve_top_docs(query, docs, model, width=3):
     query_emb = model.encode(query)
@@ -54,19 +54,11 @@ def clean_relations_bm25_sent(topn_relations, topn_scores, entity_id, head_relat
 def run_llm(prompt, temperature, max_tokens, opeani_api_keys, engine="gpt-3.5-turbo", n=1):
 
     if "llama" in engine.lower():
-        openai_api_key = "EMPTY"
-        openai_api_base = "http://localhost:7788/v1"
-
-        client = OpenAI(
-            api_key=openai_api_key,
-            base_url=openai_api_base,
-        )
-
-        models = client.models.list()
-        engine = models.data[0].id
-        print(engine)
+        if engine.lower() == "llama":
+            engine = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+        client = Together(api_key=opeani_api_keys)
     else:
-        client = openai.OpenAI(api_key=opeani_api_keys, base_url="<your_api_url>")
+        client = openai.OpenAI(api_key=opeani_api_keys, base_url="")
 
 
     sys_prompt = '''You are a helpful assistant'''
@@ -102,17 +94,9 @@ def run_llm(prompt, temperature, max_tokens, opeani_api_keys, engine="gpt-3.5-tu
 def run_llm_cnfin(prompt, temperature, max_tokens, opeani_api_keys, engine="gpt-3.5-turbo", n=1):
 
     if "llama" in engine.lower():
-        openai_api_key = "EMPTY"
-        openai_api_base = "http://localhost:7788/v1"
-
-        client = OpenAI(
-            api_key=openai_api_key,
-            base_url=openai_api_base,
-        )
-
-        models = client.models.list()
-        engine = models.data[0].id
-        print(engine)
+        if engine.lower() == "llama":
+            engine = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+        client = Together(api_key=opeani_api_keys)
     else:
         client = openai.OpenAI(api_key=opeani_api_keys, base_url="https://api.gptsapi.net/v1")
 

--- a/ToG-2/wiki_func.py
+++ b/ToG-2/wiki_func.py
@@ -1,7 +1,7 @@
 import time,openai,json,random,heapq,math
 from utils import *
 from search import *
-from openai import OpenAI
+from together import Together
 
 def transform_relation(wiki_relation):
     relation_without_prefix = wiki_relation.replace("wiki.relation.", "").replace("_", " ")
@@ -290,17 +290,9 @@ def relation_search(entity_id, entity_name, pre_relations, pre_head, question, a
 
 def run_llm_json(prompt, temperature, max_tokens, openai_api_keys, args, engine="gpt-3.5-turbo"):
     if "llama" in engine.lower():
-        openai_api_key = "EMPTY"
-        openai_api_base = "http://localhost:7788/v1"
-
-        client = OpenAI(
-            api_key=openai_api_key,
-            base_url=openai_api_base,
-        )
-
-        models = client.models.list()
-        engine = models.data[0].id
-        print(engine)
+        if engine.lower() == "llama":
+            engine = "meta-llama/Meta-Llama-3.1-8B-Instruct"
+        client = Together(api_key=openai_api_keys)
         res_format = {"type": "text"}
     else:
         client = openai.OpenAI(api_key=openai_api_keys, base_url="")

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,6 +118,7 @@ nvidia-nvtx-cu12==12.1.105
 oauthlib==3.2.2
 onnxruntime==1.16.3
 openai==1.50.2
+together==1.5.25
 openpyxl==3.1.5
 opentelemetry-api==1.21.0
 opentelemetry-exporter-otlp-proto-common==1.21.0


### PR DESCRIPTION
## Summary
- integrate Together API client to run Llama models
- document how to run ToG-2 with Together-hosted Llama
- include Together library in dependencies

## Testing
- `python -m py_compile ToG-2/utils.py ToG-2/wiki_func.py ToG-2/main_tog2.py`
- `python ToG-2/main_tog2.py --help` *(fails: ModuleNotFoundError: No module named 'rank_bm25')*


------
https://chatgpt.com/codex/tasks/task_e_68a0a6ab6ce4833195ec2bd64230b05e